### PR TITLE
chore(ci): run release-please only after CI passes

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,7 +1,10 @@
 name: Release Please
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - main
 
@@ -13,6 +16,8 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # Only run if CI workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Run Release Please
         uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4


### PR DESCRIPTION
Changed release-please trigger from push to workflow_run, so it only runs after the CI workflow completes successfully. This ensures we don't create release PRs for code that fails CI checks.