### PR TITLE
fix(main): make skills subcommands honor --help/-h instead of executing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,6 +124,7 @@ release:
     logs-mcp-server skills install            # user-level (~/.agents/skills/)
     logs-mcp-server skills install --project  # project-level (./.agents/skills/)
     logs-mcp-server skills list               # see all available skills
+    logs-mcp-server skills remove             # remove installed skills
     ```
 
     See the [README](https://github.com/tareqmamari/cloud-logs-mcp#installation) for full setup instructions including Claude Desktop configuration.
@@ -166,6 +167,8 @@ brews:
         logs-mcp-server skills list               # list available skills
         logs-mcp-server skills install             # reinstall to ~/.agents/skills/
         logs-mcp-server skills install --project   # install to current project
+        logs-mcp-server skills remove              # remove from ~/.agents/skills/
+        logs-mcp-server skills remove --project    # remove from current project
 
       For more information, see: https://github.com/tareqmamari/cloud-logs-mcp
 

--- a/internal/tools/metamorphic_test.go
+++ b/internal/tools/metamorphic_test.go
@@ -502,7 +502,7 @@ func filterBySeverity(result map[string]interface{}, minSeverity float64) map[st
 func formatContentToString(result interface{}) string {
 	// Use reflection to extract text content from MCP CallToolResult
 	v := reflect.ValueOf(result)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
@@ -518,7 +518,7 @@ func formatContentToString(result interface{}) string {
 		if item.Kind() == reflect.Interface {
 			item = item.Elem()
 		}
-		if item.Kind() == reflect.Ptr {
+		if item.Kind() == reflect.Pointer {
 			item = item.Elem()
 		}
 		if item.Kind() == reflect.Struct {

--- a/main.go
+++ b/main.go
@@ -164,6 +164,13 @@ func runSkillsCommand(args []string) {
 		return
 	}
 
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			printSkillsUsage()
+			return
+		}
+	}
+
 	switch args[0] {
 	case "install":
 		projectLevel := false

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn while capturing everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
+	}
+	return string(out)
+}
+
+func TestRunSkillsCommandHelpFlag(t *testing.T) {
+	// Isolate from the real home directory so an accidental execution
+	// cannot touch the user's installed skills.
+	t.Setenv("HOME", t.TempDir())
+
+	subcommands := []string{"install", "list", "remove"}
+	helpFlags := []string{"--help", "-h"}
+
+	for _, sub := range subcommands {
+		for _, flag := range helpFlags {
+			t.Run(sub+" "+flag, func(t *testing.T) {
+				out := captureStdout(t, func() {
+					runSkillsCommand([]string{sub, flag})
+				})
+
+				if !strings.Contains(out, "Usage: logs-mcp-server skills") {
+					t.Errorf("expected usage text, got:\n%s", out)
+				}
+				for _, executed := range []string{"Installed", "Removed", "skills available", "found to remove"} {
+					if strings.Contains(out, executed) {
+						t.Errorf("command executed instead of showing help (found %q):\n%s", executed, out)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `skills install|list|remove` only scanned trailing args for `--project`, so unknown flags were silently ignored — `logs-mcp-server skills remove --help` actually deleted installed skills instead of printing usage. Subcommands now print usage when `--help`/`-h` is present, with a regression test covering all three subcommands.
- Documents the existing `skills remove` command in the GoReleaser release notes and Homebrew caveats, which previously only mentioned `install` and `list`.

## Test plan

- [x] New `TestRunSkillsCommandHelpFlag` in `main_test.go` (written first, watched fail, then fixed)
- [x] `go test ./...` passes
- [x] Verified end-to-end: `go run . skills remove --help` prints usage and leaves `~/.agents/skills/ibm-cloud-logs` untouched